### PR TITLE
Add function to set UV bounds on overlays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,18 @@ impl Default for ColorTint {
     }
 }
 
+pub struct TextureBounds(pub sys::VRTextureBounds_t);
+impl Clone for TextureBounds {
+    fn clone(&self) -> Self {
+        Self(sys::VRTextureBounds_t {
+            uMin: self.0.uMin,
+            vMin: self.0.vMin,
+            uMax: self.0.uMax,
+            vMax: self.0.vMax,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -294,9 +294,15 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err).map(|_| parent_overlay.into())
     }
 
-    pub fn set_texture_bounds(&mut self, overlay: OverlayHandle, bounds: &sys::VRTextureBounds_t) -> Result<(), EVROverlayError> {
+    pub fn set_texture_bounds(
+        &mut self,
+        overlay: OverlayHandle,
+        bounds: &sys::VRTextureBounds_t,
+    ) -> Result<(), EVROverlayError> {
         let err = unsafe {
-            self.inner.as_mut().SetOverlayTextureBounds(overlay.0, bounds)
+            self.inner
+                .as_mut()
+                .SetOverlayTextureBounds(overlay.0, bounds)
         };
         EVROverlayError::new(err)
     }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,6 +1,7 @@
 pub use crate::errors::EVROverlayError;
 use crate::pose::Matrix3x4;
 use crate::pose::TrackingUniverseOrigin;
+use crate::TextureBounds;
 use crate::{sys, ColorTint, Context};
 
 use derive_more::From;
@@ -297,12 +298,12 @@ impl<'c> OverlayManager<'c> {
     pub fn set_texture_bounds(
         &mut self,
         overlay: OverlayHandle,
-        bounds: &sys::VRTextureBounds_t,
+        bounds: &TextureBounds,
     ) -> Result<(), EVROverlayError> {
         let err = unsafe {
             self.inner
                 .as_mut()
-                .SetOverlayTextureBounds(overlay.0, bounds)
+                .SetOverlayTextureBounds(overlay.0, &bounds.0)
         };
         EVROverlayError::new(err)
     }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -293,6 +293,13 @@ impl<'c> OverlayManager<'c> {
         };
         EVROverlayError::new(err).map(|_| parent_overlay.into())
     }
+
+    pub fn set_texture_bounds(&mut self, overlay: OverlayHandle, bounds: &sys::VRTextureBounds_t) -> Result<(), EVROverlayError> {
+        let err = unsafe {
+            self.inner.as_mut().SetOverlayTextureBounds(overlay.0, bounds)
+        };
+        EVROverlayError::new(err)
+    }
 }
 unsafe impl Send for OverlayManager<'_> {}
 unsafe impl Sync for OverlayManager<'_> {}

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -22,6 +22,8 @@ include_cpp! {
 
     generate_pod!("vr::ETrackingUniverseOrigin")
     generate!("vr::HmdMatrix34_t")
+
+    generate_pod!("vr::VRTextureBounds_t")
 }
 
 //pub use ffi::vr::*;


### PR DESCRIPTION
requirement so we can scroll the texture on the overlay for rotation visualization in the slimevr overlay.

can add the get_texture_bounds function as well, but it wasn't immediately necessary so I didn't.