### PR TITLE
Initial bindings for input subsystem.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+ovr_input = []
+
 [dependencies]
 ovr_overlay_sys = { version = "=0.0.0", path = "sys" }
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = "0.99"
 log = "0.4"
 nalgebra = { version = "0.30", optional = true }
 slice-of-array = "0.3"
+enumset = "1.0.12"
 
 
 [workspace]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,7 +59,10 @@ impl Display for EVROverlayError {
     }
 }
 
+#[cfg(feature = "ovr_input")]
 pub struct EVRInputError(sys::EVRInputError);
+
+#[cfg(feature = "ovr_input")]
 impl EVRInputError {
     pub fn new(err: sys::EVRInputError) -> Result<(), Self> {
         if err == sys::EVRInputError::VRInputError_None {
@@ -77,6 +80,8 @@ impl EVRInputError {
         self.0
     }
 }
+
+#[cfg(feature = "ovr_input")]
 impl Display for EVRInputError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let num = self.0 as u8;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,7 +75,30 @@ impl EVRInputError {
     }
 
     pub fn description(&self) -> &'static str {
-        "todo"
+        use sys::EVRInputError::*;
+        match self.0 {
+            VRInputError_None => "None",
+            VRInputError_NameNotFound => "NameNotFound",
+            VRInputError_WrongType => "WrongType",
+            VRInputError_InvalidHandle => "InvalidHandle",
+            VRInputError_InvalidParam => "InvalidParam",
+            VRInputError_NoSteam => "NoSteam",
+            VRInputError_MaxCapacityReached => "MaxCapacityReached",
+            VRInputError_IPCError => "IPCError",
+            VRInputError_NoActiveActionSet => "NoActiveActionSet",
+            VRInputError_InvalidDevice => "InvalidDevice",
+            VRInputError_InvalidSkeleton => "InvalidSkeleton",
+            VRInputError_InvalidBoneCount => "InvalidBoneCount",
+            VRInputError_InvalidCompressedData => "InvalidCompressedData",
+            VRInputError_NoData => "NoData",
+            VRInputError_BufferTooSmall => "BufferTooSmall",
+            VRInputError_MismatchedActionManifest => "MismatchedActionManifest",
+            VRInputError_MissingSkeletonData => "MissingSkeletonData",
+            VRInputError_InvalidBoneIndex => "InvalidBoneIndex",
+            VRInputError_InvalidPriority => "InvalidPriority",
+            VRInputError_PermissionDenied => "PermissionDenied",
+            VRInputError_InvalidRenderModel => "InvalidRenderModel",
+        }
     }
 
     pub fn inner(&self) -> sys::EVRInputError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 use crate::sys;
 
-use derive_more::From;
+use derive_more::{From, Into};
 use std::ffi::CStr;
 use std::fmt::Display;
 
@@ -60,6 +60,8 @@ impl Display for EVROverlayError {
 }
 
 #[cfg(feature = "ovr_input")]
+#[derive(From, Into, Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[repr(transparent)]
 pub struct EVRInputError(sys::EVRInputError);
 
 #[cfg(feature = "ovr_input")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,6 +59,32 @@ impl Display for EVROverlayError {
     }
 }
 
+pub struct EVRInputError(sys::EVRInputError);
+impl EVRInputError {
+    pub fn new(err: sys::EVRInputError) -> Result<(), Self> {
+        if err == sys::EVRInputError::VRInputError_None {
+            Ok(())
+        } else {
+            Err(Self(err))
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        "todo"
+    }
+
+    pub fn inner(&self) -> sys::EVRInputError {
+        self.0
+    }
+}
+impl Display for EVRInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let num = self.0 as u8;
+        let desc = self.description();
+        write!(f, "EVRInputError({num}): {desc}")
+    }
+}
+
 #[derive(Debug, From, thiserror::Error)]
 pub enum InitError {
     #[error("OpenVR already initialized")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,7 +33,7 @@ impl<'c> InputManager<'c> {
         }
     }
 
-    // handle management functions
+    // ---- Handle Management ----
 
     pub fn set_action_manifest(&mut self, path: &Path) -> Result<(), EVRInputError> {
         let path = if let Ok(s) = CString::new(path.to_string_lossy().as_bytes()) {
@@ -138,7 +138,7 @@ impl<'c> InputManager<'c> {
         Ok(InputValueHandle(handle))
     }
 
-    // Reading action state
+    // ---- Read Action State ----
 
     pub fn update_actions(
         &mut self,
@@ -196,7 +196,7 @@ impl<'c> InputManager<'c> {
         Ok(unsafe { data.assume_init() })
     }
 
-    // Action Origins
+    // ---- Action Origins ----
 
     // TODO: GetOriginLocalizedName -- this is gonna want a nice bitset UI
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -56,8 +56,7 @@ impl<'c> InputManager<'c> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
-            return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam)
-                .map(|_| unreachable!());
+            return Err(sys::EVRInputError::VRInputError_InvalidParam.into());
         };
 
         self.get_action_set_handle_raw(&name)

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,211 @@
+use crate::{errors::EVRInputError, pose, sys, Context};
+
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+#[cfg(unix)]
+use std::os::unix::prelude::OsStrExt;
+#[cfg(windows)]
+use std::os::windows::prelude::OsStrExt;
+use std::path::Path;
+use std::pin::Pin;
+
+pub struct InputManager<'c> {
+    ctx: PhantomData<&'c Context>,
+    inner: Pin<&'c mut sys::IVRInput>,
+}
+
+impl<'c> InputManager<'c> {
+    pub(super) fn new(_ctx: &'c Context) -> Self {
+        let inner = unsafe { Pin::new_unchecked(sys::VRInput().as_mut::<'c>().unwrap()) };
+        Self {
+            ctx: Default::default(),
+            inner,
+        }
+    }
+
+    // handle management functions
+
+    pub fn set_action_manifest(&mut self, path: &Path) -> Result<(), EVRInputError> {
+        let path = if let Ok(s) = CString::new(path.as_os_str().as_bytes()) {
+            s
+        } else {
+            return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam);
+        };
+        self.set_action_manifest_raw(&path)
+    }
+
+    pub fn set_action_manifest_raw(&mut self, path: &CStr) -> Result<(), EVRInputError> {
+        let err = unsafe { self.inner.as_mut().SetActionManifestPath(path.as_ptr()) };
+        EVRInputError::new(err)
+    }
+
+    pub fn get_action_set_handle(
+        &mut self,
+        name: &str,
+    ) -> Result<sys::VRActionSetHandle_t, EVRInputError> {
+        let name = if let Ok(s) = CString::new(name) {
+            s
+        } else {
+            return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam)
+                .map(|_| unreachable!());
+        };
+
+        self.get_action_set_handle_raw(&name)
+    }
+
+    pub fn get_action_set_handle_raw(
+        &mut self,
+        name: &CStr,
+    ) -> Result<sys::VRActionSetHandle_t, EVRInputError> {
+        let mut handle: sys::VRActionSetHandle_t = 0;
+
+        let err = unsafe {
+            self.inner
+                .as_mut()
+                .GetActionSetHandle(name.as_ptr(), &mut handle)
+        };
+
+        EVRInputError::new(err)?;
+        Ok(handle)
+    }
+
+    pub fn get_action_handle(
+        &mut self,
+        name: &str,
+    ) -> Result<sys::VRActionHandle_t, EVRInputError> {
+        let name = if let Ok(s) = CString::new(name) {
+            s
+        } else {
+            return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam)
+                .map(|_| unreachable!());
+        };
+
+        self.get_action_handle_raw(&name)
+    }
+
+    pub fn get_action_handle_raw(
+        &mut self,
+        name: &CStr,
+    ) -> Result<sys::VRActionHandle_t, EVRInputError> {
+        let mut handle: sys::VRActionHandle_t = 0;
+
+        let err = unsafe {
+            self.inner
+                .as_mut()
+                .GetActionHandle(name.as_ptr(), &mut handle)
+        };
+
+        EVRInputError::new(err)?;
+        Ok(handle)
+    }
+
+    pub fn get_input_source_handle(
+        &mut self,
+        name: &str,
+    ) -> Result<sys::VRInputValueHandle_t, EVRInputError> {
+        let name = if let Ok(s) = CString::new(name) {
+            s
+        } else {
+            return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam)
+                .map(|_| unreachable!());
+        };
+
+        self.get_input_source_handle_raw(&name)
+    }
+
+    pub fn get_input_source_handle_raw(
+        &mut self,
+        name: &CStr,
+    ) -> Result<sys::VRInputValueHandle_t, EVRInputError> {
+        let mut handle: sys::VRInputValueHandle_t = 0;
+
+        let err = unsafe {
+            self.inner
+                .as_mut()
+                .GetInputSourceHandle(name.as_ptr(), &mut handle)
+        };
+
+        EVRInputError::new(err)?;
+        Ok(handle)
+    }
+
+    // Reading action state
+
+    pub fn update_actions(
+        &mut self,
+        sets: &mut [sys::VRActiveActionSet_t],
+    ) -> Result<(), EVRInputError> {
+        let err = unsafe {
+            self.inner.as_mut().UpdateActionState(
+                sets.as_mut_ptr(),
+                std::mem::size_of::<sys::VRActiveActionSet_t>() as u32,
+                sets.len() as u32,
+            )
+        };
+
+        EVRInputError::new(err)
+    }
+
+    pub fn get_digital_action_data(
+        &mut self,
+        action: sys::VRActionHandle_t,
+        restrict: sys::VRInputValueHandle_t,
+    ) -> Result<sys::InputDigitalActionData_t, EVRInputError> {
+        let mut data: MaybeUninit<sys::InputDigitalActionData_t> = MaybeUninit::uninit();
+        let err = unsafe {
+            self.inner.as_mut().GetDigitalActionData(
+                action,
+                data.as_mut_ptr(),
+                std::mem::size_of::<sys::VRActiveActionSet_t>() as u32,
+                restrict,
+            )
+        };
+        EVRInputError::new(err)?;
+        Ok(unsafe { data.assume_init() })
+    }
+
+    pub fn get_pose_action_data_relative_to_now(
+        &mut self,
+        action: sys::VRActionHandle_t,
+        universe: pose::TrackingUniverseOrigin,
+        seconds_from_now: f32,
+        restrict: sys::VRInputValueHandle_t,
+    ) -> Result<sys::InputPoseActionData_t, EVRInputError> {
+        let mut data: MaybeUninit<sys::InputPoseActionData_t> = MaybeUninit::uninit();
+        let err = unsafe {
+            self.inner.as_mut().GetPoseActionDataRelativeToNow(
+                action,
+                universe,
+                seconds_from_now,
+                data.as_mut_ptr(),
+                std::mem::size_of::<sys::InputPoseActionData_t>() as u32,
+                restrict,
+            )
+        };
+
+        EVRInputError::new(err)?;
+        Ok(unsafe { data.assume_init() })
+    }
+
+    // Action Origins
+
+    // TODO: GetOriginLocalizedName -- this is gonna want a nice bitset UI
+
+    pub fn get_origin_tracked_device_info(
+        &mut self,
+        origin: sys::VRInputValueHandle_t,
+    ) -> Result<sys::InputOriginInfo_t, EVRInputError> {
+        let mut data: MaybeUninit<sys::InputOriginInfo_t> = MaybeUninit::uninit();
+        let err = unsafe {
+            self.inner.as_mut().GetOriginTrackedDeviceInfo(
+                origin,
+                data.as_mut_ptr(),
+                std::mem::size_of::<sys::InputOriginInfo_t>() as u32,
+            )
+        };
+
+        EVRInputError::new(err)?;
+        Ok(unsafe { data.assume_init() })
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,6 @@
 use crate::{errors::EVRInputError, pose, sys, Context};
 
-use derive_more::From;
+use derive_more::{From, Into};
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
@@ -12,13 +12,16 @@ pub struct InputManager<'c> {
     inner: Pin<&'c mut sys::IVRInput>,
 }
 
-#[derive(From, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(From, Into, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(transparent)]
 pub struct ActionSetHandle(sys::VRActionSetHandle_t);
 
-#[derive(From, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(From, Into, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(transparent)]
 pub struct ActionHandle(sys::VRActionHandle_t);
 
-#[derive(From, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(From, Into, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(transparent)]
 pub struct InputValueHandle(sys::VRInputValueHandle_t);
 
 impl<'c> InputManager<'c> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -180,7 +180,7 @@ impl<'c> InputManager<'c> {
             self.inner.as_mut().GetDigitalActionData(
                 action.0,
                 data.as_mut_ptr(),
-                std::mem::size_of::<sys::VRActiveActionSet_t>() as u32,
+                std::mem::size_of::<sys::InputDigitalActionData_t>() as u32,
                 restrict.0,
             )
         };

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,10 +3,6 @@ use crate::{errors::EVRInputError, pose, sys, Context};
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
-#[cfg(unix)]
-use std::os::unix::prelude::OsStrExt;
-#[cfg(windows)]
-use std::os::windows::prelude::OsStrExt;
 use std::path::Path;
 use std::pin::Pin;
 
@@ -27,7 +23,7 @@ impl<'c> InputManager<'c> {
     // handle management functions
 
     pub fn set_action_manifest(&mut self, path: &Path) -> Result<(), EVRInputError> {
-        let path = if let Ok(s) = CString::new(path.as_os_str().as_bytes()) {
+        let path = if let Ok(s) = CString::new(path.to_string_lossy().as_bytes()) {
             s
         } else {
             return EVRInputError::new(sys::EVRInputError::VRInputError_InvalidParam);

--- a/src/input.rs
+++ b/src/input.rs
@@ -72,10 +72,7 @@ impl<'c> InputManager<'c> {
         EVRInputError::new(err)
     }
 
-    pub fn get_action_set_handle(
-        &mut self,
-        name: &str,
-    ) -> Result<ActionSetHandle, EVRInputError> {
+    pub fn get_action_set_handle(&mut self, name: &str) -> Result<ActionSetHandle, EVRInputError> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
@@ -101,10 +98,7 @@ impl<'c> InputManager<'c> {
         Ok(ActionSetHandle(handle))
     }
 
-    pub fn get_action_handle(
-        &mut self,
-        name: &str,
-    ) -> Result<ActionHandle, EVRInputError> {
+    pub fn get_action_handle(&mut self, name: &str) -> Result<ActionHandle, EVRInputError> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
@@ -115,10 +109,7 @@ impl<'c> InputManager<'c> {
         self.get_action_handle_raw(&name)
     }
 
-    pub fn get_action_handle_raw(
-        &mut self,
-        name: &CStr,
-    ) -> Result<ActionHandle, EVRInputError> {
+    pub fn get_action_handle_raw(&mut self, name: &CStr) -> Result<ActionHandle, EVRInputError> {
         let mut handle: sys::VRActionHandle_t = 0;
 
         let err = unsafe {

--- a/src/input.rs
+++ b/src/input.rs
@@ -25,6 +25,8 @@ pub struct ActionHandle(sys::VRActionHandle_t);
 #[repr(transparent)]
 pub struct InputValueHandle(sys::VRInputValueHandle_t);
 
+type Result<T> = std::result::Result<T, EVRInputError>;
+
 pub trait ToSeconds {
     fn to_seconds(self) -> f32;
 }
@@ -58,7 +60,7 @@ impl<'c> InputManager<'c> {
 
     // ---- Handle Management ----
 
-    pub fn set_action_manifest(&mut self, path: &Path) -> Result<(), EVRInputError> {
+    pub fn set_action_manifest(&mut self, path: &Path) -> Result<()> {
         let path = if let Ok(s) = CString::new(path.to_string_lossy().as_bytes()) {
             s
         } else {
@@ -67,12 +69,12 @@ impl<'c> InputManager<'c> {
         self.set_action_manifest_raw(&path)
     }
 
-    pub fn set_action_manifest_raw(&mut self, path: &CStr) -> Result<(), EVRInputError> {
+    pub fn set_action_manifest_raw(&mut self, path: &CStr) -> Result<()> {
         let err = unsafe { self.inner.as_mut().SetActionManifestPath(path.as_ptr()) };
         EVRInputError::new(err)
     }
 
-    pub fn get_action_set_handle(&mut self, name: &str) -> Result<ActionSetHandle, EVRInputError> {
+    pub fn get_action_set_handle(&mut self, name: &str) -> Result<ActionSetHandle> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
@@ -82,10 +84,7 @@ impl<'c> InputManager<'c> {
         self.get_action_set_handle_raw(&name)
     }
 
-    pub fn get_action_set_handle_raw(
-        &mut self,
-        name: &CStr,
-    ) -> Result<ActionSetHandle, EVRInputError> {
+    pub fn get_action_set_handle_raw(&mut self, name: &CStr) -> Result<ActionSetHandle> {
         let mut handle: sys::VRActionSetHandle_t = 0;
 
         let err = unsafe {
@@ -98,7 +97,7 @@ impl<'c> InputManager<'c> {
         Ok(ActionSetHandle(handle))
     }
 
-    pub fn get_action_handle(&mut self, name: &str) -> Result<ActionHandle, EVRInputError> {
+    pub fn get_action_handle(&mut self, name: &str) -> Result<ActionHandle> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
@@ -109,7 +108,7 @@ impl<'c> InputManager<'c> {
         self.get_action_handle_raw(&name)
     }
 
-    pub fn get_action_handle_raw(&mut self, name: &CStr) -> Result<ActionHandle, EVRInputError> {
+    pub fn get_action_handle_raw(&mut self, name: &CStr) -> Result<ActionHandle> {
         let mut handle: sys::VRActionHandle_t = 0;
 
         let err = unsafe {
@@ -122,10 +121,7 @@ impl<'c> InputManager<'c> {
         Ok(ActionHandle(handle))
     }
 
-    pub fn get_input_source_handle(
-        &mut self,
-        name: &str,
-    ) -> Result<InputValueHandle, EVRInputError> {
+    pub fn get_input_source_handle(&mut self, name: &str) -> Result<InputValueHandle> {
         let name = if let Ok(s) = CString::new(name) {
             s
         } else {
@@ -136,10 +132,7 @@ impl<'c> InputManager<'c> {
         self.get_input_source_handle_raw(&name)
     }
 
-    pub fn get_input_source_handle_raw(
-        &mut self,
-        name: &CStr,
-    ) -> Result<InputValueHandle, EVRInputError> {
+    pub fn get_input_source_handle_raw(&mut self, name: &CStr) -> Result<InputValueHandle> {
         let mut handle: sys::VRInputValueHandle_t = 0;
 
         let err = unsafe {
@@ -154,10 +147,7 @@ impl<'c> InputManager<'c> {
 
     // ---- Read Action State ----
 
-    pub fn update_actions(
-        &mut self,
-        sets: &mut [sys::VRActiveActionSet_t],
-    ) -> Result<(), EVRInputError> {
+    pub fn update_actions(&mut self, sets: &mut [sys::VRActiveActionSet_t]) -> Result<()> {
         let err = unsafe {
             self.inner.as_mut().UpdateActionState(
                 sets.as_mut_ptr(),
@@ -173,7 +163,7 @@ impl<'c> InputManager<'c> {
         &mut self,
         action: ActionHandle,
         restrict: InputValueHandle,
-    ) -> Result<sys::InputDigitalActionData_t, EVRInputError> {
+    ) -> Result<sys::InputDigitalActionData_t> {
         let mut data: MaybeUninit<sys::InputDigitalActionData_t> = MaybeUninit::uninit();
         let err = unsafe {
             self.inner.as_mut().GetDigitalActionData(
@@ -193,7 +183,7 @@ impl<'c> InputManager<'c> {
         universe: pose::TrackingUniverseOrigin,
         seconds_from_now: impl ToSeconds,
         restrict: InputValueHandle,
-    ) -> Result<sys::InputPoseActionData_t, EVRInputError> {
+    ) -> Result<sys::InputPoseActionData_t> {
         let mut data: MaybeUninit<sys::InputPoseActionData_t> = MaybeUninit::uninit();
         let err = unsafe {
             self.inner.as_mut().GetPoseActionDataRelativeToNow(
@@ -217,7 +207,7 @@ impl<'c> InputManager<'c> {
     pub fn get_origin_tracked_device_info(
         &mut self,
         origin: InputValueHandle,
-    ) -> Result<sys::InputOriginInfo_t, EVRInputError> {
+    ) -> Result<sys::InputOriginInfo_t> {
         let mut data: MaybeUninit<sys::InputOriginInfo_t> = MaybeUninit::uninit();
         let err = unsafe {
             self.inner.as_mut().GetOriginTrackedDeviceInfo(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub use ovr_overlay_sys as sys;
 
 use self::overlay::OverlayManager;
 
+#[cfg(feature = "ovr_input")]
+use self::input::InputManager;
+
 use derive_more::{From, Into};
 use lazy_static::lazy_static;
 use std::fmt::Debug;
@@ -63,8 +66,8 @@ impl Context {
     }
 
     #[cfg(feature = "ovr_input")]
-    pub fn input_mngr(&self) -> input::InputManager<'_> {
-        input::InputManager::new(self)
+    pub fn input_mngr(&self) -> InputManager<'_> {
+        InputManager::new(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! **This library makes no semver guarantees until version 0.1.0 or greater.**
 
+#[cfg(feature = "ovr_input")]
 pub mod input;
 pub mod overlay;
 pub mod pose;
@@ -61,6 +62,7 @@ impl Context {
         OverlayManager::new(self)
     }
 
+    #[cfg(feature = "ovr_input")]
     pub fn input_mngr(&self) -> input::InputManager<'_> {
         input::InputManager::new(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! **This library makes no semver guarantees until version 0.1.0 or greater.**
 
+pub mod input;
 pub mod overlay;
 pub mod pose;
 
@@ -58,6 +59,10 @@ impl Context {
 
     pub fn overlay_mngr(&self) -> OverlayManager<'_> {
         OverlayManager::new(self)
+    }
+
+    pub fn input_mngr(&self) -> input::InputManager<'_> {
+        input::InputManager::new(self)
     }
 }
 

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -24,6 +24,18 @@ include_cpp! {
     generate!("vr::HmdMatrix34_t")
 
     generate_pod!("vr::VRTextureBounds_t")
+
+    // input
+    generate!("vr::IVRInput")
+    generate!("vr::VRInput")
+    generate_pod!("vr::VRActionSetHandle_t")
+    generate_pod!("vr::VRActionHandle_t")
+    generate_pod!("vr::VRInputValueHandle_t")
+    generate_pod!("vr::VRActiveActionSet_t")
+    generate_pod!("vr::InputDigitalActionData_t")
+    generate_pod!("vr::TrackedDevicePose_t")
+    generate_pod!("vr::InputPoseActionData_t")
+    generate_pod!("vr::InputOriginInfo_t")
 }
 
 //pub use ffi::vr::*;

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -28,6 +28,7 @@ include_cpp! {
     // input
     generate!("vr::IVRInput")
     generate!("vr::VRInput")
+    generate_pod!("vr::EVRInputError")
     generate_pod!("vr::VRActionSetHandle_t")
     generate_pod!("vr::VRActionHandle_t")
     generate_pod!("vr::VRInputValueHandle_t")


### PR DESCRIPTION
Includes most things that the feeder app/overlay wants, aside from GetOriginLocalizedName (which needs a bitset I haven't implemented yet).

Currently using types directly from sys, might want to wrap some of these types.

PR is currently a draft, because at the very least there is one more function I intend to implement, then I'll work on wrappers for types from sys.