### PR TITLE
Initial implementation of ChaperoneSetup::ExportLiveToBuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.58"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+ovr_chaperone_setup = []
 ovr_input = []
 
 [dependencies]

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -1,14 +1,9 @@
-use crate::{errors::EVRInputError, pose, sys, Context};
+use crate::{sys, Context};
 
-use derive_more::{From, Into};
-use enumset::{EnumSet, EnumSetType};
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
-use std::path::Path;
 use std::pin::Pin;
 use std::ptr::null_mut;
-use std::time::Duration;
 
 pub struct ChaperoneSetupManager<'c> {
     ctx: PhantomData<&'c Context>,

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -22,6 +22,7 @@ impl<'c> ChaperoneSetupManager<'c> {
     // TODO: this outputs json, could we pass it directly to something that does json?
     pub fn export_live_to_buffer(&mut self) -> Option<CString> {
         let mut len = 0u32;
+        // Passing null pointer here means it will merely write to the length parameter.
         let res = unsafe { self.inner.as_mut().ExportLiveToBuffer(null_mut(), &mut len) };
         if !res || len == 0 {
             return None;

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -1,0 +1,47 @@
+use crate::{errors::EVRInputError, pose, sys, Context};
+
+use derive_more::{From, Into};
+use enumset::{EnumSet, EnumSetType};
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::path::Path;
+use std::pin::Pin;
+use std::ptr::null_mut;
+use std::time::Duration;
+
+pub struct ChaperoneSetupManager<'c> {
+    ctx: PhantomData<&'c Context>,
+    inner: Pin<&'c mut sys::IVRChaperoneSetup>,
+}
+
+impl<'c> ChaperoneSetupManager<'c> {
+    pub(super) fn new(_ctx: &'c Context) -> Self {
+        let inner = unsafe { Pin::new_unchecked(sys::VRChaperoneSetup().as_mut::<'c>().unwrap()) };
+        Self {
+            ctx: Default::default(),
+            inner,
+        }
+    }
+
+    // TODO: this outputs json, could we pass it directly to something that does json?
+    pub fn export_live_to_buffer(&mut self) -> Option<CString> {
+        let mut len = 0u32;
+        let res = unsafe { self.inner.as_mut().ExportLiveToBuffer(null_mut(), &mut len) };
+        if !res || len == 0 {
+            return None;
+        }
+
+        let mut data = vec![0u8; len as usize];
+        let res = unsafe {
+            self.inner
+                .as_mut()
+                .ExportLiveToBuffer(data.as_mut_ptr() as *mut i8, &mut len)
+        };
+        if res {
+            CString::from_vec_with_nul(data).ok()
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! **This library makes no semver guarantees until version 0.1.0 or greater.**
 
+#[cfg(feature = "ovr_chaperone_setup")]
+pub mod chaperone_setup;
 #[cfg(feature = "ovr_input")]
 pub mod input;
 pub mod overlay;
@@ -14,6 +16,8 @@ pub use ovr_overlay_sys as sys;
 
 use self::overlay::OverlayManager;
 
+#[cfg(feature = "ovr_chaperone_setup")]
+use self::chaperone_setup::ChaperoneSetupManager;
 #[cfg(feature = "ovr_input")]
 use self::input::InputManager;
 
@@ -63,6 +67,11 @@ impl Context {
 
     pub fn overlay_mngr(&self) -> OverlayManager<'_> {
         OverlayManager::new(self)
+    }
+
+    #[cfg(feature = "ovr_chaperone_setup")]
+    pub fn chaperone_setup_mngr(&self) -> ChaperoneSetupManager<'_> {
+        ChaperoneSetupManager::new(self)
     }
 
     #[cfg(feature = "ovr_input")]

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -17,6 +17,9 @@ include_cpp! {
     generate_pod!("vr::EVROverlayError")
     generate_pod!("vr::VROverlayHandle_t")
 
+    generate!("vr::IVRChaperoneSetup")
+    generate!("vr::VRChaperoneSetup")
+
     generate!("vr::VR_GetVRInitErrorAsSymbol")
     generate_pod!("vr::EVRInitError")
 


### PR DESCRIPTION
Currently just returning CString, we probably want to turn that into a string (or whatever is most convienent to pass to a json parser)