### PR TITLE
Initial wrapper of {Set,Get}OverlayTransformTrackedDeviceRelative

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -261,7 +261,7 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err).map(|_| origin)
     }
 
-    pub fn set_transform_overlay_tracked_device_relative(
+    pub fn set_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
         index: sys::TrackedDeviceIndex_t,
@@ -269,14 +269,14 @@ impl<'c> OverlayManager<'c> {
     ) -> Result<(), EVROverlayError> {
         let device_to_overlay: &sys::HmdMatrix34_t = device_to_overlay.into();
         let err = unsafe {
-            self.inner.as_mut().SetOverlayTransformTrackedDeviceRelative(overlay.0, index, device_to_overlay)
+            self.inner
+                .as_mut()
+                .SetOverlayTransformTrackedDeviceRelative(overlay.0, index, device_to_overlay)
         };
         EVROverlayError::new(err)
     }
 
-    /** Gets the transform if it is relative to a tracked device. Returns an error if the transform is some other type. */
-    //virtual EVROverlayError GetOverlayTransformTrackedDeviceRelative( VROverlayHandle_t ulOverlayHandle, TrackedDeviceIndex_t *punTrackedDevice, HmdMatrix34_t *pmatTrackedDeviceToOverlayTransform ) = 0;
-    pub fn get_transform_overlay_tracked_device_relative(
+    pub fn get_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
         device_to_overlay: &mut Matrix3x4,
@@ -284,15 +284,12 @@ impl<'c> OverlayManager<'c> {
         let mut index = sys::TrackedDeviceIndex_t::default();
         let device_to_overlay: &mut sys::HmdMatrix34_t = device_to_overlay.into();
         let err = unsafe {
-            self.inner.as_mut().GetOverlayTransformTrackedDeviceRelative(
-                overlay.0,
-                &mut index,
-                device_to_overlay,
-            )
+            self.inner
+                .as_mut()
+                .GetOverlayTransformTrackedDeviceRelative(overlay.0, &mut index, device_to_overlay)
         };
         EVROverlayError::new(err).map(|_| index)
     }
-
 
     pub fn set_transform_overlay_relatve(
         &mut self,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -302,7 +302,10 @@ impl<'c> OverlayManager<'c> {
         };
         EVROverlayError::new(err)?;
         // TODO: is the error ever really going to be delayed to here? (Can we successfully return an invalid handle?)
-        TrackedDeviceIndex::new(index).or(EVROverlayError::new(sys::EVROverlayError::VROverlayError_RequestFailed).map(|_| unreachable!()))
+        TrackedDeviceIndex::new(index).or(EVROverlayError::new(
+            sys::EVROverlayError::VROverlayError_RequestFailed,
+        )
+        .map(|_| unreachable!()))
     }
 
     /// Sets the transform for this overlay, relative to another overlay.

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -228,6 +228,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err)
     }
 
+    /// Sets an absolute transform for this overlay.
+    ///
+    /// Wrapper around SetOverlayTransformAbsolute.
     pub fn set_transform_absolute(
         &mut self,
         overlay: OverlayHandle,
@@ -243,6 +246,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err)
     }
 
+    /// Gets the absolute transform for this overlay.
+    ///
+    /// Wrapper around GetOverlayTransformAbsolute.
     pub fn get_transform_absolute(
         &mut self,
         overlay: OverlayHandle,
@@ -261,6 +267,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err).map(|_| origin)
     }
 
+    /// Sets the transform for this overlay, relative to a tracked device.
+    ///
+    /// Wrapper around SetOverlayTransformTrackedDeviceRelative.
     pub fn set_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
@@ -276,6 +285,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err)
     }
 
+    /// Gets the transform for this overlay, relative to a tracked device.
+    ///
+    /// Wrapper around GetOverlayTransformTrackedDeviceRelative.
     pub fn get_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
@@ -291,6 +303,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err).map(|_| index)
     }
 
+    /// Sets the transform for this overlay, relative to another overlay.
+    ///
+    /// Wrapper around SetOverlayTransformOverlayRelative.
     pub fn set_transform_overlay_relatve(
         &mut self,
         child_overlay: OverlayHandle,
@@ -308,6 +323,9 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err)
     }
 
+    /// Gets the transform for this overlay, relative to another overlay.
+    ///
+    /// Wrapper around GetOverlayTransformOverlayRelative.
     pub fn get_transform_overlay_relative(
         &mut self,
         child_overlay: OverlayHandle,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -261,6 +261,39 @@ impl<'c> OverlayManager<'c> {
         EVROverlayError::new(err).map(|_| origin)
     }
 
+    pub fn set_transform_overlay_tracked_device_relative(
+        &mut self,
+        overlay: OverlayHandle,
+        index: sys::TrackedDeviceIndex_t,
+        device_to_overlay: &Matrix3x4,
+    ) -> Result<(), EVROverlayError> {
+        let device_to_overlay: &sys::HmdMatrix34_t = device_to_overlay.into();
+        let err = unsafe {
+            self.inner.as_mut().SetOverlayTransformTrackedDeviceRelative(overlay.0, index, device_to_overlay)
+        };
+        EVROverlayError::new(err)
+    }
+
+    /** Gets the transform if it is relative to a tracked device. Returns an error if the transform is some other type. */
+    //virtual EVROverlayError GetOverlayTransformTrackedDeviceRelative( VROverlayHandle_t ulOverlayHandle, TrackedDeviceIndex_t *punTrackedDevice, HmdMatrix34_t *pmatTrackedDeviceToOverlayTransform ) = 0;
+    pub fn get_transform_overlay_tracked_device_relative(
+        &mut self,
+        overlay: OverlayHandle,
+        device_to_overlay: &mut Matrix3x4,
+    ) -> Result<sys::TrackedDeviceIndex_t, EVROverlayError> {
+        let mut index = sys::TrackedDeviceIndex_t::default();
+        let device_to_overlay: &mut sys::HmdMatrix34_t = device_to_overlay.into();
+        let err = unsafe {
+            self.inner.as_mut().GetOverlayTransformTrackedDeviceRelative(
+                overlay.0,
+                &mut index,
+                device_to_overlay,
+            )
+        };
+        EVROverlayError::new(err).map(|_| index)
+    }
+
+
     pub fn set_transform_overlay_relatve(
         &mut self,
         child_overlay: OverlayHandle,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -2,7 +2,7 @@ pub use crate::errors::EVROverlayError;
 use crate::pose::Matrix3x4;
 use crate::pose::TrackingUniverseOrigin;
 use crate::TextureBounds;
-use crate::{sys, ColorTint, Context};
+use crate::{sys, ColorTint, Context, TrackedDeviceIndex};
 
 use derive_more::From;
 use std::marker::PhantomData;
@@ -273,14 +273,14 @@ impl<'c> OverlayManager<'c> {
     pub fn set_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
-        index: sys::TrackedDeviceIndex_t,
+        index: TrackedDeviceIndex,
         device_to_overlay: &Matrix3x4,
     ) -> Result<(), EVROverlayError> {
         let device_to_overlay: &sys::HmdMatrix34_t = device_to_overlay.into();
         let err = unsafe {
             self.inner
                 .as_mut()
-                .SetOverlayTransformTrackedDeviceRelative(overlay.0, index, device_to_overlay)
+                .SetOverlayTransformTrackedDeviceRelative(overlay.0, index.0, device_to_overlay)
         };
         EVROverlayError::new(err)
     }
@@ -292,7 +292,7 @@ impl<'c> OverlayManager<'c> {
         &mut self,
         overlay: OverlayHandle,
         device_to_overlay: &mut Matrix3x4,
-    ) -> Result<sys::TrackedDeviceIndex_t, EVROverlayError> {
+    ) -> Result<TrackedDeviceIndex, EVROverlayError> {
         let mut index = sys::TrackedDeviceIndex_t::default();
         let device_to_overlay: &mut sys::HmdMatrix34_t = device_to_overlay.into();
         let err = unsafe {
@@ -300,7 +300,9 @@ impl<'c> OverlayManager<'c> {
                 .as_mut()
                 .GetOverlayTransformTrackedDeviceRelative(overlay.0, &mut index, device_to_overlay)
         };
-        EVROverlayError::new(err).map(|_| index)
+        EVROverlayError::new(err)?;
+        // TODO: is the error ever really going to be delayed to here? (Can we successfully return an invalid handle?)
+        TrackedDeviceIndex::new(index).or(EVROverlayError::new(sys::EVROverlayError::VROverlayError_RequestFailed).map(|_| unreachable!()))
     }
 
     /// Sets the transform for this overlay, relative to another overlay.

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -230,7 +230,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Sets an absolute transform for this overlay.
     ///
-    /// Wrapper around SetOverlayTransformAbsolute.
+    /// Wraps c++ `SetOverlayTransformAbsolute`.
     pub fn set_transform_absolute(
         &mut self,
         overlay: OverlayHandle,
@@ -248,7 +248,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Gets the absolute transform for this overlay.
     ///
-    /// Wrapper around GetOverlayTransformAbsolute.
+    /// Wraps c++ `GetOverlayTransformAbsolute`.
     pub fn get_transform_absolute(
         &mut self,
         overlay: OverlayHandle,
@@ -269,7 +269,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Sets the transform for this overlay, relative to a tracked device.
     ///
-    /// Wrapper around SetOverlayTransformTrackedDeviceRelative.
+    /// Wraps c++ `SetOverlayTransformTrackedDeviceRelative`.
     pub fn set_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
@@ -287,7 +287,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Gets the transform for this overlay, relative to a tracked device.
     ///
-    /// Wrapper around GetOverlayTransformTrackedDeviceRelative.
+    /// Wraps c++ `GetOverlayTransformTrackedDeviceRelative`.
     pub fn get_transform_tracked_device_relative(
         &mut self,
         overlay: OverlayHandle,
@@ -305,7 +305,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Sets the transform for this overlay, relative to another overlay.
     ///
-    /// Wrapper around SetOverlayTransformOverlayRelative.
+    /// Wraps c++ `SetOverlayTransformOverlayRelative`.
     pub fn set_transform_overlay_relatve(
         &mut self,
         child_overlay: OverlayHandle,
@@ -325,7 +325,7 @@ impl<'c> OverlayManager<'c> {
 
     /// Gets the transform for this overlay, relative to another overlay.
     ///
-    /// Wrapper around GetOverlayTransformOverlayRelative.
+    /// Wraps c++ `GetOverlayTransformOverlayRelative`.
     pub fn get_transform_overlay_relative(
         &mut self,
         child_overlay: OverlayHandle,


### PR DESCRIPTION
I was working on wrappers anyway, so I decided I'd work on #7 while I was at it.

I'm proabably going to get a complaint that I should be wrapping sys::TrackedDeviceIndex_t in a newtype, I'll set that up somewhere eventually.

Obtaining the Matrix3x4, I'm following prior convention in this file, but it feels a bit non-idiomatic.