### PR TITLE
Add Applications

### DIFF
--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -47,6 +47,11 @@ include_cpp! {
     generate_pod!("vr::TrackedDevicePose_t")
     generate_pod!("vr::InputPoseActionData_t")
     generate_pod!("vr::InputOriginInfo_t")
+
+    // applications
+    generate!("vr::IVRApplications")
+    generate!("vr::VRApplications")
+    generate_pod!("vr::EVRApplicationError")
 }
 
 //pub use ffi::vr::*;


### PR DESCRIPTION
Related to #13  

I'm not very experienced with C/C++, I'm not sure if you wanted the `ovr_applications` feature flag for the sys crate, the other flags appear to only be used for the library crate.  

I did try but you can't put `#[cfg(feature = "ovr_applications")]` directly in the `include_cpp!` macro block without an error, and adding a second macro block also didn't work.  