### PR TITLE
More type-safe version of property API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ log = "0.4"
 nalgebra = { version = "0.30", optional = true }
 slice-of-array = "0.3"
 enumset = "1.0.12"
+paste = "1.0"
+macro_rules_attribute = "0.1.3"
 
 
 [workspace]

--- a/src/system.rs
+++ b/src/system.rs
@@ -13,6 +13,8 @@ pub struct SystemManager<'c> {
 
 mod private {
     pub trait Sealed {}
+    // TODO: this may be overkill, but it encodes exactly how restrictive I want the sealing to be.
+    pub trait SealedProperty<T> {}
 }
 
 type PropResult<T> = Result<T, ETrackedPropertyError>;
@@ -130,6 +132,251 @@ impl TrackedDeviceProperty for CString {
 
 // TODO: arrays. I don't feel like dealing with them right now.
 
+pub trait TrackedDevicePropertyName<Output: TrackedDeviceProperty>:
+    private::SealedProperty<Output> + Into<sys::ETrackedDeviceProperty>
+{
+    fn get(self, index: TrackedDeviceIndex, system: &mut SystemManager) -> PropResult<Output> {
+        Output::get(index, system, self.into())
+    }
+}
+
+pub mod props {
+    use crate::pose::Matrix3x4;
+    use macro_rules_attribute::apply;
+
+    use super::*;
+
+    macro_rules! props_enum {
+        (
+            $( #[$meta:meta] )*
+            $vis:vis enum $type:ident {
+                $($variant:ident),+ $(,)?
+            }
+        ) => {
+            ::paste::paste! {
+                #[repr(i32)]
+                $( #[$meta] )*
+                $vis enum $type {
+                    $($variant = crate::sys::ETrackedDeviceProperty::[<Prop_ $variant _ $type>] as i32,)+
+                }
+            }
+        };
+    }
+
+    // first s/^\s+Prop_[a-zA-Z0-9_]+_(?!Bool)[a-zA-Z0-9]+ .*\n//\
+    // remove Prop_ParentContainer
+    // then s/Prop_([a-zA-Z0-9_]+)_Bool/$1/
+    // TODO: update regex to match macro approach
+
+    #[apply(props_enum!)]
+    #[allow(non_camel_case_types)]
+    pub enum Bool {
+        WillDriftInYaw,
+        DeviceIsWireless,
+        DeviceIsCharging,
+        Firmware_UpdateAvailable,
+        Firmware_ManualUpdate,
+        BlockServerShutdown,
+        CanUnifyCoordinateSystemWithHmd,
+        ContainsProximitySensor,
+        DeviceProvidesBatteryStatus,
+        DeviceCanPowerOff,
+        HasCamera,
+        Firmware_ForceUpdateRequired,
+        ViveSystemButtonFixRequired,
+        NeverTracked,
+        Identifiable,
+        Firmware_RemindUpdate,
+        ReportsTimeSinceVSync,
+        IsOnDesktop,
+        DisplaySuppressed,
+        DisplayAllowNightMode,
+        DriverDirectModeSendsVsyncEvents,
+        DisplayDebugMode,
+        DoNotApplyPrediction,
+        DriverIsDrawingControllers,
+        DriverRequestsApplicationPause,
+        DriverRequestsReducedRendering,
+        ConfigurationIncludesLighthouse20Features,
+        DriverProvidedChaperoneVisibility,
+        CameraSupportsCompatibilityModes,
+        SupportsRoomViewDepthProjection,
+        DisplaySupportsMultipleFramerates,
+        DisplaySupportsRuntimeFramerateChange,
+        DisplaySupportsAnalogGain,
+        Hmd_SupportsHDCP14LegacyCompat,
+        Hmd_SupportsMicMonitoring,
+        Audio_SupportsDualSpeakerAndJackOutput,
+        CanWirelessIdentify,
+        HasDisplayComponent,
+        HasControllerComponent,
+        HasCameraComponent,
+        HasDriverDirectModeComponent,
+        HasVirtualDisplayComponent,
+        HasSpatialAnchorsSupport,
+    }
+
+    #[apply(props_enum!)]
+    #[allow(non_camel_case_types)]
+    pub enum Int32 {
+        DeviceClass,
+        NumCameras,
+        CameraFrameLayout,
+        CameraStreamFormat,
+        EstimatedDeviceFirstUseTime,
+        DisplayMCType,
+        EdidVendorID,
+        EdidProductID,
+        DisplayGCType,
+        CameraCompatibilityMode,
+        DisplayMCImageWidth,
+        DisplayMCImageHeight,
+        DisplayMCImageNumChannels,
+        ExpectedTrackingReferenceCount,
+        ExpectedControllerCount,
+        DistortionMeshResolution,
+        HmdTrackingStyle,
+        DriverRequestedMuraCorrectionMode,
+        DriverRequestedMuraFeather_InnerLeft,
+        DriverRequestedMuraFeather_InnerRight,
+        DriverRequestedMuraFeather_InnerTop,
+        DriverRequestedMuraFeather_InnerBottom,
+        DriverRequestedMuraFeather_OuterLeft,
+        DriverRequestedMuraFeather_OuterRight,
+        DriverRequestedMuraFeather_OuterTop,
+        DriverRequestedMuraFeather_OuterBottom,
+        Axis0Type,
+        Axis1Type,
+        Axis2Type,
+        Axis3Type,
+        Axis4Type,
+        ControllerRoleHint,
+        Nonce,
+        ControllerHandSelectionPriority,
+    }
+
+    #[apply(props_enum!)]
+    #[allow(non_camel_case_types)]
+    pub enum Uint64 {
+        HardwareRevision,
+        FirmwareVersion,
+        FPGAVersion,
+        VRCVersion,
+        RadioVersion,
+        DongleVersion,
+        ParentDriver,
+        BootloaderVersion,
+        PeripheralApplicationVersion,
+        CurrentUniverseId,
+        PreviousUniverseId,
+        DisplayFirmwareVersion,
+        CameraFirmwareVersion,
+        DisplayFPGAVersion,
+        DisplayBootloaderVersion,
+        DisplayHardwareVersion,
+        AudioFirmwareVersion,
+        GraphicsAdapterLuid,
+        AudioBridgeFirmwareVersion,
+        ImageBridgeFirmwareVersion,
+        AdditionalRadioFeatures,
+        SupportedButtons,
+        OverrideContainer,
+    }
+
+    #[apply(props_enum!)]
+    #[allow(non_camel_case_types)]
+    pub enum Matrix34 {
+        StatusDisplayTransform,
+        CameraToHeadTransform,
+        ImuToHeadTransform,
+    }
+
+    #[apply(props_enum!)]
+    #[allow(non_camel_case_types)]
+    pub enum String {
+        TrackingSystemName,
+        ModelNumber,
+        SerialNumber,
+        RenderModelName,
+        ManufacturerName,
+        TrackingFirmwareVersion,
+        HardwareRevision,
+        AllWirelessDongleDescriptions,
+        ConnectedWirelessDongle,
+        Firmware_ManualUpdateURL,
+        Firmware_ProgrammingTarget,
+        DriverVersion,
+        ResourceRoot,
+        RegisteredDeviceType,
+        InputProfilePath,
+        AdditionalDeviceSettingsPath,
+        AdditionalSystemReportData,
+        CompositeFirmwareVersion,
+        ManufacturerSerialNumber,
+        ComputedSerialNumber,
+        DisplayMCImageLeft,
+        DisplayMCImageRight,
+        DisplayGCImage,
+        CameraFirmwareDescription,
+        DriverProvidedChaperonePath,
+        NamedIconPathControllerLeftDeviceOff,
+        NamedIconPathControllerRightDeviceOff,
+        NamedIconPathTrackingReferenceDeviceOff,
+        ExpectedControllerType,
+        HmdColumnCorrectionSettingPrefix,
+        Audio_DefaultPlaybackDeviceId,
+        Audio_DefaultRecordingDeviceId,
+        AttachedDeviceId,
+        ModeLabel,
+        IconPathName,
+        NamedIconPathDeviceOff,
+        NamedIconPathDeviceSearching,
+        NamedIconPathDeviceSearchingAlert,
+        NamedIconPathDeviceReady,
+        NamedIconPathDeviceReadyAlert,
+        NamedIconPathDeviceNotReady,
+        NamedIconPathDeviceStandby,
+        NamedIconPathDeviceAlertLow,
+        NamedIconPathDeviceStandbyAlert,
+        UserConfigPath,
+        InstallPath,
+        ControllerType,
+    }
+
+    // TODO: The following properties are not included here yet:
+    //  - Prop_ParentContainer (no type mentioned, but is supposed to be opaque to us anyway)
+    // The rest are arrays
+    //  - Prop_CameraToHeadTransforms_Matrix34_Array
+    //  - Prop_CameraWhiteBalance_Vector4_Array
+    //  - Prop_CameraDistortionFunction_Int32_Array
+    //  - Prop_CameraDistortionCoefficients_Float_Array
+    //  - Prop_DisplayAvailableFrameRates_Float_Array
+
+    macro_rules! impl_property {
+        ($enum:ty; $($ty:ty),+) => {
+            pub use $enum::*;
+            impl From<$enum> for sys::ETrackedDeviceProperty {
+                fn from(t: $enum) -> Self {
+                    unsafe { std::mem::transmute(t) } // TODO: Into+FromPrimitive?
+                }
+            }
+            $(
+                impl private::SealedProperty<$ty> for $enum {}
+                impl TrackedDevicePropertyName<$ty> for $enum {}
+            )+
+        }
+    }
+
+    impl_property!(Bool; bool);
+    impl_property!(Int32; i32);
+    impl_property!(Uint64; u64);
+    impl_property!(Matrix34; Matrix3x4);
+    impl_property!(self::String; CString);
+
+    impl<T: private::Sealed> private::SealedProperty<T> for sys::ETrackedDeviceProperty {}
+    impl<T: TrackedDeviceProperty> TrackedDevicePropertyName<T> for sys::ETrackedDeviceProperty {}
+}
+
 impl<'c> SystemManager<'c> {
     pub(super) fn new(_ctx: &'c Context) -> Self {
         let inner = unsafe { Pin::new_unchecked(sys::VRSystem().as_mut::<'c>().unwrap()) };
@@ -139,12 +386,15 @@ impl<'c> SystemManager<'c> {
         }
     }
 
-    pub fn get_tracked_device_property<T: TrackedDeviceProperty>(
+    pub fn get_tracked_device_property<
+        T: TrackedDeviceProperty,
+        N: TrackedDevicePropertyName<T>,
+    >(
         &mut self,
         index: TrackedDeviceIndex,
-        prop: sys::ETrackedDeviceProperty,
+        prop: N,
     ) -> PropResult<T> {
-        T::get(index, self, prop)
+        N::get(prop, index, self)
     }
 }
 unsafe impl Send for SystemManager<'_> {}
@@ -154,8 +404,8 @@ unsafe impl Sync for SystemManager<'_> {}
 mod test {
     use super::*;
     fn _compile_test(mut system: SystemManager) {
-        // let _bootloader_version =
-        //     system.get_tracked_device_property(TrackedDeviceIndex::HMD, props::DisplayBootloaderVersion);
+        let _bootloader_version = system
+            .get_tracked_device_property(TrackedDeviceIndex::HMD, props::DisplayBootloaderVersion);
         let _display_version: u64 = system
             .get_tracked_device_property(
                 TrackedDeviceIndex::HMD,


### PR DESCRIPTION
This is the non-MVP version of #8. I don't need it for the overlay (since I can use the MVP for it).