### PR TITLE
Remove error check from first call to ExportLiveToBuffer.

### DIFF
--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -23,8 +23,8 @@ impl<'c> ChaperoneSetupManager<'c> {
     pub fn export_live_to_buffer(&mut self) -> Option<CString> {
         let mut len = 0u32;
         // Passing null pointer here means it will merely write to the length parameter.
-        let res = unsafe { self.inner.as_mut().ExportLiveToBuffer(null_mut(), &mut len) };
-        if !res || len == 0 {
+        let _res = unsafe { self.inner.as_mut().ExportLiveToBuffer(null_mut(), &mut len) };
+        if len == 0 {
             return None;
         }
 


### PR DESCRIPTION
This will always fail since we don't provide a buffer, so it should be safe to ignore.

This is a fix that's required for the overlay.